### PR TITLE
修复 README 星标历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <!--[![Stargazers over time](https://starchart.cc/hoochanlon/fq-book.svg)](https://starchart.cc/hoochanlon/fq-book)-->
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hoochanlon/fq-book&type=Date)](https://star-history.com/#hoochanlon/fq-book&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hoochanlon/fq-book&type=Date)](https://star-history.dera.page/#hoochanlon/fq-book&Date)
 
 ## ***update***
 


### PR DESCRIPTION
当前 README 中的星标历史图表因 GitHub stargazer API 限制已经无法正常显示，亟需修复。本 PR 将图表的图片地址与链接更新为新的图表服务，使星标历史图表重新正常展示。